### PR TITLE
fix: add dev:prepare script to vite plugin to avoid pnpm install failure

### DIFF
--- a/packages/vite-plugin-mcp/package.json
+++ b/packages/vite-plugin-mcp/package.json
@@ -34,7 +34,8 @@
     "dev": "unbuild --stub",
     "play": "nr -C playground dev",
     "prepublishOnly": "nr build",
-    "start": "nodemon --exec 'tsx src/server.ts'"
+    "start": "nodemon --exec 'tsx src/server.ts'",
+    "dev:prepare": "nr build"
   },
   "peerDependencies": {
     "vite": ">=6.0.0"


### PR DESCRIPTION
Add `dev:prepare` to vite plugin to fix failure when running `pnpm prepare` during `pnpm i`

Error message:

```shell
> @0.0.1 prepare /Users/situ/Documents/GitHub/nuxt-mcp
> simple-git-hooks && nr -r dev:prepare

[INFO] Successfully set the pre-commit with command: pnpm lint-staged
[INFO] Successfully set all git hooks
Scope: 2 of 3 workspace projects
packages/nuxt-mcp dev:prepare$ nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground
│ ℹ Stubbing nuxt-mcp
│ ℹ Cleaning dist directory: ./dist
│  ERROR  Cannot find module '/Users/situ/Documents/GitHub/nuxt-mcp/packages/nuxt-mcp/node_modules/vite-plugin-mcp/dist/index.mjs'
│     at createEsmNotFoundErr (node:internal/modules/cjs/loader:1177:15)
│     at finalizeEsmResolution (node:internal/modules/cjs/loader:1165:15)
│     at resolveExports (node:internal/modules/cjs/loader:590:14)
│     at Module._findPath (node:internal/modules/cjs/loader:664:31)
│     at Module._resolveFilename (node:internal/modules/cjs/loader:1126:27)
│     at Function.resolve (node:internal/modules/helpers:188:19)
│     at _resolve (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/dist/jiti.js:1:246378)
│     at jiti (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/dist/jiti.js:1:249092)
│     at src/module.ts:4:22
│     at evalModule (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/dist/jiti.js:1:251913)
│  ERROR  Cannot load module. Please check dist: /Users/situ/Documents/GitHub/nuxt-mcp/packages/nuxt-mcp/dist/module.mjs
│  ERROR  Error while importing module /Users/situ/Documents/GitHub/nuxt-mcp/packages/nuxt-mcp/src/module: Error: Cannot find module '/Users/situ/Documents/GitHub/nu…
│     at loadNuxtModuleInstance (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/@nuxt+kit@3.16.0_magicast@0.3.5/node_modules/@nuxt/kit/dist/index.mjs:2565:…
│     at async installModule (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/@nuxt+kit@3.16.0_magicast@0.3.5/node_modules/@nuxt/kit/dist/index.mjs:2480:67)
│     at async initNuxt (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/nuxt@3.16.0_@parcel+watcher@2.5.1_@types+node@22.13.10_db0@0.3.1_eslint@9.22.0_jiti…
│     at async loadNuxt (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/nuxt@3.16.0_@parcel+watcher@2.5.1_@types+node@22.13.10_db0@0.3.1_eslint@9.22.0_jiti…
│     at async loadNuxt (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/@nuxt+kit@3.16.0_magicast@0.3.5/node_modules/@nuxt/kit/dist/index.mjs:2713:19)
│     at async Object.run (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/nuxi@3.22.2/node_modules/nuxi/dist/chunks/prepare.mjs:47:18)
│     at async runCommand$1 (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/nuxi@3.22.2/node_modules/nuxi/dist/shared/nuxi.D5U3oSa9.mjs:1763:16)
│     at async runCommand (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/nuxi@3.22.2/node_modules/nuxi/dist/shared/nuxi.D5U3oSa9.mjs:2090:10)
│     at async runCommand (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:316:16)
│     at async runCommand (/Users/situ/Documents/GitHub/nuxt-mcp/node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:307:11) 
│  ERROR  Error while importing module /Users/situ/Documents/GitHub/nuxt-mcp/packages/nuxt-mcp/src/module: Error: Cannot find module '/Users/situ/Documents/GitHub/nu…
└─ Failed in 2.1s at /Users/situ/Documents/GitHub/nuxt-mcp/packages/nuxt-mcp
/Users/situ/Documents/GitHub/nuxt-mcp/packages/nuxt-mcp:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  nuxt-mcp@0.0.1 dev:prepare: `nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```