### PR TITLE
feat: create tool to list of available hooks available in nuxt instance

### DIFF
--- a/packages/nuxt-mcp/src/tools/runtime.ts
+++ b/packages/nuxt-mcp/src/tools/runtime.ts
@@ -84,4 +84,19 @@ export function toolsNuxtRuntime({ mcp, nuxt, unimport }: McpToolContext): void 
       }
     },
   )
+
+  mcp.tool(
+    'list-nuxt-hooks',
+    'List registered hooks in the Nuxt app.',
+    {},
+    async () => {
+      return {
+        content: [{
+          type: 'text',
+          // @ts-expect-error - private _hooks property
+          text: JSON.stringify(Object.keys(nuxt.hooks._hooks), null, 2),
+        }],
+      }
+    },
+  )
 }


### PR DESCRIPTION
### Description

Add additional tool to display all the available hooks in the nuxt application, detects modules hooks so it works quite well when trying to figure out what's available in the project

<img width="412" alt="image" src="https://github.com/user-attachments/assets/176e2848-7543-4e89-b4ce-7d45500d95b4" />

### Additional context

Currently using a private property `_hooks`, maybes there's a better way to extract the hooks. I can't seem to find anything when exploring https://github.com/unjs/hookable

### Testing
Tested against nuxt content in the playground to see if the hooks are being discovered correctly, "mdc:configSources" is available as expected
