### PR TITLE
fix: vite.environments is not exist

### DIFF
--- a/packages/vite-plugin-mcp/src/server.ts
+++ b/packages/vite-plugin-mcp/src/server.ts
@@ -27,7 +27,7 @@ export function createMcpServerDefault(
           root: vite.config.root,
           resolve: vite.config.resolve,
           plugins: vite.config.plugins.map(p => p.name).filter(Boolean),
-          environmentNames: Object.keys(vite.environments),
+          environmentNames: Object.keys(vite.config.env),
         }),
       }],
     }),
@@ -42,7 +42,7 @@ export function createMcpServerDefault(
     },
     async ({ filepath }) => {
       const records: any[] = []
-      Object.entries(vite.environments).forEach(([key, env]) => {
+      Object.entries(vite.config.env).forEach(([key, env]) => {
         const mods = env.moduleGraph.getModulesByFile(filepath)
         for (const mod of mods || []) {
           records.push({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I guess vite.environments was probably meant to express vite.config.env

### Linked Issues

https://github.com/antfu/nuxt-mcp/issues/9

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
