### PR TITLE
Use HTTPS protocol when https is enabled in Vite

### DIFF
--- a/packages/vite-plugin-mcp/src/index.ts
+++ b/packages/vite-plugin-mcp/src/index.ts
@@ -36,7 +36,8 @@ export function ViteMcp(options: ViteMcpOptions = {}): Plugin {
       const port = vite.config.server.port
       const root = searchForWorkspaceRoot(vite.config.root)
 
-      const sseUrl = `http://${options.host || 'localhost'}:${options.port || port}${mcpPath}/sse`
+      const protocol = vite.config.server.https ? 'https' : 'http'
+      const sseUrl = `${protocol}://${options.host || 'localhost'}:${options.port || port}${mcpPath}/sse`
 
       if (cursorMcpOptions.enabled) {
         if (existsSync(join(root, '.cursor'))) {


### PR DESCRIPTION
Update `sseUrl` to use `https` protocol when `https` is enabled in Vite.

* Determine the protocol based on `vite.config.server.https` option.
* Construct the `sseUrl` using the determined protocol, host, and port options.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/antfu/nuxt-mcp/pull/12?shareId=ebe25aa0-b44e-4ff1-8c31-3ee3e31de79e).