### PR TITLE
feat: support the windsurf mcp config (fixes #8) 

### DIFF
--- a/packages/nuxt-mcp/src/module.ts
+++ b/packages/nuxt-mcp/src/module.ts
@@ -22,6 +22,12 @@ export interface ModuleOptions {
    * @default true
    */
   updateVSCodeMcpJson?: boolean
+  /**
+   * Update MCP url to `~/.codeium/windsurf/mcp_config.json` automatically
+   *
+   * @default true
+   */
+  updateWindsurfMcpJson?: boolean
 }
 
 export interface ModuleHooks {
@@ -36,6 +42,7 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     updateCursorMcpJson: true,
     updateVSCodeMcpJson: true,
+    updateWindsurfMcpJson: true,
   },
   async setup(options, nuxt) {
     const unimport = promiseWithResolve<Unimport>()
@@ -56,6 +63,10 @@ export default defineNuxtModule<ModuleOptions>({
       },
       updateVSCodeMcpJson: {
         enabled: !!options.updateVSCodeMcpJson,
+        serverName: 'nuxt',
+      },
+      updateWindsurfMcpJson: {
+        enabled: !!options.updateWindsurfMcpJson,
         serverName: 'nuxt',
       },
       mcpServerInfo: {

--- a/packages/vite-plugin-mcp/src/types.ts
+++ b/packages/vite-plugin-mcp/src/types.ts
@@ -71,4 +71,18 @@ export interface ViteMcpOptions {
      */
     serverName?: string
   }
+
+  /**
+   * Update the address of the MCP server in the Windsurf config file `~/.codeium/windsurf/mcp_config.json`,
+   * if Windsurf config file exists.
+   *
+   * @default true
+   */
+  updateWindsurfMcpJson?: boolean | {
+    enabled: boolean
+    /**
+     * The name of the MCP server, default is `vite`
+     */
+    serverName?: string
+  }
 }


### PR DESCRIPTION
### Description
 
Adds support for the windsurf editor so it creates the config in the correct location. There probably a more dry way of implementing all these options

### Linked Issues

fix #8 