### PR TITLE
fix: use options.port if provided

### DIFF
--- a/packages/vite-plugin-mcp/src/index.ts
+++ b/packages/vite-plugin-mcp/src/index.ts
@@ -23,6 +23,7 @@ export function ViteMcp(options: ViteMcpOptions = {}): Plugin {
   return {
     name: 'vite-plugin-mcp',
     async configureServer(vite) {
+      vite.config.server.port = options.port || vite.config.server.port
       let mcp = await mcpServer(vite)
       mcp = await options.mcpServerSetup?.(mcp, vite) || mcp
       await setupRoutes(mcpRoute, mcp, vite)
@@ -31,7 +32,7 @@ export function ViteMcp(options: ViteMcpOptions = {}): Plugin {
       const root = searchForWorkspaceRoot(vite.config.root)
 
       const protocol = vite.config.server.https ? 'https' : 'http'
-      const sseUrl = `${protocol}://${options.host || 'localhost'}:${options.port || port}${mcpRoute}/sse`
+      const sseUrl = `${protocol}://${options.host || 'localhost'}:${port}${mcpRoute}/sse`
 
       if (printUrl) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

There's a `port` option in the viteMCP options and but its being ignored and only shows in the logs as if it was set. 

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
