### PR TITLE
chore(vite): fix package.json homepage and repository

### DIFF
--- a/packages/vite-plugin-mcp/package.json
+++ b/packages/vite-plugin-mcp/package.json
@@ -7,12 +7,13 @@
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",
   "funding": "https://github.com/sponsors/antfu",
-  "homepage": "https://github.com/antfu/vite-plugin-mcp#readme",
+  "homepage": "https://github.com/antfu/nuxt-mcp/tree/main/packages/vite-plugin-mcp",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/antfu/vite-plugin-mcp.git"
+    "url": "git+https://github.com/antfu/nuxt-mcp.git",
+    "directory": "packages/vite-plugin-mcp"
   },
-  "bugs": "https://github.com/antfu/vite-plugin-mcp/issues",
+  "bugs": "https://github.com/antfu/nuxt-mcp/issues",
   "keywords": [
     "vite-plugin",
     "mcp",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I noticed the repository link on npm is 404 https://github.com/antfu/vite-plugin-mcp. This PR updates `package.json` to point to this repository.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
