### PR TITLE
fix: move tools registration to composition

### DIFF
--- a/packages/nuxt-mcp/src/module.ts
+++ b/packages/nuxt-mcp/src/module.ts
@@ -5,7 +5,7 @@ import type { McpToolContext } from './types'
 import { addVitePlugin, defineNuxtModule } from '@nuxt/kit'
 import { ViteMcp } from 'vite-plugin-mcp'
 import { promptNuxtBasic } from './prompts/basic'
-import { toolsNuxtRuntime } from './tools/runtime'
+import { useToolsRuntime } from './tools/runtime'
 import { toolsScaffold } from './tools/scaffold'
 
 export interface ModuleOptions extends ViteMcpOptions {
@@ -35,6 +35,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const unimport = promiseWithResolve<Unimport>()
     const nitro = promiseWithResolve<Nitro>()
+    const { registerTools } = useToolsRuntime()
 
     nuxt.hook('imports:context', (_unimport) => {
       unimport.resolve(_unimport)
@@ -69,7 +70,7 @@ export default defineNuxtModule<ModuleOptions>({
         }
 
         promptNuxtBasic(context)
-        toolsNuxtRuntime(context)
+        registerTools(context)
         toolsScaffold(context)
 
         // eslint-disable-next-line ts/ban-ts-comment

--- a/packages/nuxt-mcp/src/tools/runtime.ts
+++ b/packages/nuxt-mcp/src/tools/runtime.ts
@@ -1,87 +1,96 @@
 import type { Component, NuxtPage } from '@nuxt/schema'
 import type { McpToolContext } from '../types'
+import { useNuxt } from '@nuxt/kit'
 
-export function toolsNuxtRuntime({ mcp, nuxt, unimport }: McpToolContext): void {
-  mcp.tool(
-    'get-nuxt-config',
-    'Get the Nuxt configuration, including the ssr, appDir, srcDir, rootDir, alias, runtimeConfig, modules, etc.',
-    {},
-    async () => {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            ssr: !!nuxt.options.ssr,
-            appDir: nuxt.options.appDir,
-            srcDir: nuxt.options.srcDir,
-            rootDir: nuxt.options.rootDir,
-            alias: nuxt.options.alias,
-            runtimeConfig: {
-              public: nuxt.options.runtimeConfig.public,
-            },
-            modules: nuxt.options._installedModules.map(i => i.meta.name || (i as any).name).filter(Boolean),
-            imports: {
-              autoImport: !!nuxt.options.imports.autoImport,
-              ...nuxt.options.imports,
-            },
-            components: nuxt.options.components,
-          }),
-        }],
-      }
-    },
-  )
-
-  mcp.tool(
-    'list-nuxt-auto-imports-items',
-    'List auto-imports items, when importing new functions to the code, check available items from this tool.',
-    {},
-    async () => {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            items: await (await unimport).getImports(),
-          }, null, 2),
-        }],
-      }
-    },
-  )
-
-  let components: Component[] = []
-  nuxt.hook('components:extend', (_components) => {
-    components = _components
-  })
-
-  mcp.tool(
-    'list-nuxt-components',
-    'List registered components in the Nuxt app. When adding importing new components, check available components from this tool.',
-    {},
-    async () => {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify(components, null, 2),
-        }],
-      }
-    },
-  )
+export function useToolsRuntime(): {
+  registerTools: (context: McpToolContext) => void
+} {
+  const nuxt = useNuxt()
 
   let pages: NuxtPage[] = []
   nuxt.hook('pages:extend', (_pages) => {
     pages = _pages
   })
 
-  mcp.tool(
-    'list-nuxt-pages',
-    'List registered pages and their metadata in the Nuxt app.',
-    {},
-    async () => {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify(pages, null, 2),
-        }],
-      }
-    },
-  )
+  let components: Component[] = []
+  nuxt.hook('components:extend', (_components) => {
+    components = _components
+  })
+
+  function registerTools({ mcp, unimport }: McpToolContext): void {
+    mcp.tool(
+      'get-nuxt-config',
+      'Get the Nuxt configuration, including the ssr, appDir, srcDir, rootDir, alias, runtimeConfig, modules, etc.',
+      {},
+      async () => {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              ssr: !!nuxt.options.ssr,
+              appDir: nuxt.options.appDir,
+              srcDir: nuxt.options.srcDir,
+              rootDir: nuxt.options.rootDir,
+              alias: nuxt.options.alias,
+              runtimeConfig: {
+                public: nuxt.options.runtimeConfig.public,
+              },
+              modules: nuxt.options._installedModules.map(i => i.meta.name || (i as any).name).filter(Boolean),
+              imports: {
+                autoImport: !!nuxt.options.imports.autoImport,
+                ...nuxt.options.imports,
+              },
+              components: nuxt.options.components,
+            }),
+          }],
+        }
+      },
+    )
+
+    mcp.tool(
+      'list-nuxt-auto-imports-items',
+      'List auto-imports items, when importing new functions to the code, check available items from this tool.',
+      {},
+      async () => {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              items: await (await unimport).getImports(),
+            }, null, 2),
+          }],
+        }
+      },
+    )
+
+    mcp.tool(
+      'list-nuxt-components',
+      'List registered components in the Nuxt app. When adding importing new components, check available components from this tool.',
+      {},
+      async () => {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(components, null, 2),
+          }],
+        }
+      },
+    )
+
+    mcp.tool(
+      'list-nuxt-pages',
+      'List registered pages and their metadata in the Nuxt app.',
+      {},
+      async () => {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(pages, null, 2),
+          }],
+        }
+      },
+    )
+  }
+
+  return { registerTools }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes list-nuxt-pages and list-nuxt-components. If you start you're project and make an agent request pages or components using one of theses tools, the mcp server returns an empty array.

The issues lies with when the `components:extend` and `pages:extend` hook are registered. They are registered in `mcpServerSetup` which runs after nuxt calls `components:extend` and `pages:extend`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
