### PR TITLE
fix: update nuxt-docs mcp url

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -7,7 +7,7 @@
       "url": "http://localhost:4000/__mcp/sse"
     },
     "nuxt-docs": {
-      "url": "https://mcp.nuxt.com/sse"
+      "url": "https://nuxt.com/mcp"
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,8 @@
 {
   "servers": {
     "nuxt-docs": {
-      "type": "sse",
-      "url": "https://mcp.nuxt.com/sse"
+      "type": "http",
+      "url": "https://nuxt.com/mcp"
     },
     "vite": {
       "type": "sse",

--- a/packages/nuxt-mcp-dev/src/module.ts
+++ b/packages/nuxt-mcp-dev/src/module.ts
@@ -10,7 +10,7 @@ import { toolsScaffold } from './tools/scaffold'
 
 export interface ModuleOptions extends ViteMcpOptions {
   /**
-   * Includes the online Nuxt MCP server from https://mcp.nuxt.com/sse
+   * Includes the online Nuxt MCP server from https://nuxt.com/mcp
    *
    * This MCP would provide information about the Nuxt ecosystem, including
    * the latest documentation, available modules, etc.
@@ -53,7 +53,7 @@ export default defineNuxtModule<ModuleOptions>({
           options.includeNuxtDocsMcp
             ? [{
                 name: 'nuxt-docs',
-                url: 'https://mcp.nuxt.com/sse',
+                url: 'https://nuxt.com/mcp',
               }]
             : []),
       ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

I updated the Nuxt docs online MCP server URL, idk when it changed, but it's not `https://mcp.nuxt.com/sse` anymore, it's `https://nuxt.com/mcp` with `http` type ([link to offical docs](https://nuxt.com/docs/4.x/guide/ai/mcp#setup)). 

### Linked Issues

No linked issues

### Additional context

N/A
